### PR TITLE
Fix Postgres lookups/JDBC parameter config option

### DIFF
--- a/src/main/java/net/coreprotect/config/Config.java
+++ b/src/main/java/net/coreprotect/config/Config.java
@@ -44,6 +44,7 @@ public class Config extends Language {
     public String DB_DATABASE;
     public String DB_USERNAME;
     public String DB_PASSWORD;
+	public String DB_JDBC_PARAMETERS;
     public String LANGUAGE;
     public boolean ENABLE_AWE;
     public boolean ENABLE_SSL;
@@ -105,6 +106,7 @@ public class Config extends Language {
         DEFAULT_VALUES.put("db-database", "database");
         DEFAULT_VALUES.put("db-username", "root");
         DEFAULT_VALUES.put("db-password", "");
+        DEFAULT_VALUES.put("db-jdbc-parameters", "");
         DEFAULT_VALUES.put("language", "en");
         DEFAULT_VALUES.put("check-updates", "true");
         DEFAULT_VALUES.put("api-enabled", "true");
@@ -148,6 +150,7 @@ public class Config extends Language {
 
         HEADERS.put("donation-key", new String[] { "# CoreProtect is donationware. Obtain a donation key from coreprotect.net/donate/" });
         HEADERS.put("db-type", new String[] { "# The database type to use. By default this is \"sqlite\"", "# Available options: sqlite, mysql, pgsql" });
+        HEADERS.put("db-jdbc-parameters", new String[] { "# Extra parameters to append to the JDBC connection string. Only needed for advanced cases." });
         HEADERS.put("language", new String[] { "# If modified, will automatically attempt to translate languages phrases.", "# List of language codes: https://coreprotect.net/languages/" });
         HEADERS.put("check-updates", new String[] { "# If enabled, CoreProtect will check for updates when your server starts up.", "# If an update is available, you'll be notified via your server console.", });
         HEADERS.put("api-enabled", new String[] { "# If enabled, other plugins will be able to utilize the CoreProtect API.", });
@@ -230,6 +233,7 @@ public class Config extends Language {
         if (this.DB_PASSWORD == null && this.has("mysql-password")) {
             this.DB_PASSWORD = this.getString("mysql-password");
         }
+		this.DB_JDBC_PARAMETERS = this.getString("db-jdbc-parameters");
         this.LANGUAGE = this.getString("language");
         this.CHECK_UPDATES = this.getBoolean("check-updates");
         this.API_ENABLED = this.getBoolean("api-enabled");

--- a/src/main/java/net/coreprotect/config/Config.java
+++ b/src/main/java/net/coreprotect/config/Config.java
@@ -44,7 +44,7 @@ public class Config extends Language {
     public String DB_DATABASE;
     public String DB_USERNAME;
     public String DB_PASSWORD;
-	public String DB_JDBC_PARAMETERS;
+    public String DB_JDBC_PARAMETERS;
     public String LANGUAGE;
     public boolean ENABLE_AWE;
     public boolean ENABLE_SSL;
@@ -233,7 +233,7 @@ public class Config extends Language {
         if (this.DB_PASSWORD == null && this.has("mysql-password")) {
             this.DB_PASSWORD = this.getString("mysql-password");
         }
-		this.DB_JDBC_PARAMETERS = this.getString("db-jdbc-parameters");
+        this.DB_JDBC_PARAMETERS = this.getString("db-jdbc-parameters");
         this.LANGUAGE = this.getString("language");
         this.CHECK_UPDATES = this.getBoolean("check-updates");
         this.API_ENABLED = this.getBoolean("api-enabled");

--- a/src/main/java/net/coreprotect/config/ConfigHandler.java
+++ b/src/main/java/net/coreprotect/config/ConfigHandler.java
@@ -52,7 +52,7 @@ public class ConfigHandler extends Queue {
     public static String database = "database";
     public static String username = "root";
     public static String password = "";
-	public static String jdbcParameters = "";
+    public static String jdbcParameters = "";
     public static String prefix = "co_";
     public static int maximumPoolSize = 10;
 

--- a/src/main/java/net/coreprotect/config/ConfigHandler.java
+++ b/src/main/java/net/coreprotect/config/ConfigHandler.java
@@ -52,6 +52,7 @@ public class ConfigHandler extends Queue {
     public static String database = "database";
     public static String username = "root";
     public static String password = "";
+	public static String jdbcParameters = "";
     public static String prefix = "co_";
     public static int maximumPoolSize = 10;
 
@@ -177,6 +178,7 @@ public class ConfigHandler extends Queue {
             ConfigHandler.database = Config.getGlobal().DB_DATABASE;
             ConfigHandler.username = Config.getGlobal().DB_USERNAME;
             ConfigHandler.password = Config.getGlobal().DB_PASSWORD;
+            ConfigHandler.jdbcParameters = Config.getGlobal().DB_JDBC_PARAMETERS;
             ConfigHandler.maximumPoolSize = Config.getGlobal().MAXIMUM_POOL_SIZE;
             ConfigHandler.prefix = Config.getGlobal().DB_PREFIX;
 
@@ -230,7 +232,7 @@ public class ConfigHandler extends Queue {
                 config.setDriverClassName("com.mysql.jdbc.Driver");
             }
 
-            config.setJdbcUrl("jdbc:mysql://" + ConfigHandler.host + ":" + ConfigHandler.port + "/" + ConfigHandler.database);
+            config.setJdbcUrl("jdbc:mysql://" + ConfigHandler.host + ":" + ConfigHandler.port + "/" + ConfigHandler.database + ConfigHandler.jdbcParameters);
             config.setUsername(ConfigHandler.username);
             config.setPassword(ConfigHandler.password);
             config.setMaximumPoolSize(ConfigHandler.maximumPoolSize);
@@ -260,7 +262,7 @@ public class ConfigHandler extends Queue {
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
-            config.setJdbcUrl("jdbc:postgresql://" + ConfigHandler.host + ":" + ConfigHandler.port + "/" + ConfigHandler.database);
+            config.setJdbcUrl("jdbc:postgresql://" + ConfigHandler.host + ":" + ConfigHandler.port + "/" + ConfigHandler.database + ConfigHandler.jdbcParameters);
             config.setUsername(ConfigHandler.username);
             config.setPassword(ConfigHandler.password);
             config.setMaxLifetime(300000);

--- a/src/main/java/net/coreprotect/database/Database.java
+++ b/src/main/java/net/coreprotect/database/Database.java
@@ -409,7 +409,7 @@ public class Database extends Queue {
                     statement.executeUpdate("create index if not exists \"" + prefix + "user_uuid_index\" on \"" + prefix + "user\" (\"uuid\")");
 
                     statement.executeUpdate("create table if not exists \"" + prefix + "username_log\" (\"rowid\" bigserial primary key not null, \"time\" integer not null, \"uuid\" uuid not null, \"user\" varchar(100) not null)");
-                    statement.executeUpdate("create index if not exists \"" + prefix + "username_log_uuid_user_index\" on \"username_log\" (\"uuid\", \"user\")");
+                    statement.executeUpdate("create index if not exists \"" + prefix + "username_log_uuid_user_index\" on \"" + prefix + "username_log\" (\"uuid\", \"user\")");
 
                     statement.executeUpdate("create table if not exists \"" + prefix + "version\" (\"rowid\" bigserial primary key not null, \"time\" integer not null, \"version\" varchar(16) not null)");
 

--- a/src/main/java/net/coreprotect/database/Lookup.java
+++ b/src/main/java/net/coreprotect/database/Lookup.java
@@ -356,6 +356,7 @@ public class Lookup extends Queue {
             String unionLimit = "";
             String index = "";
             String query = "";
+			String alias = "";
 
             if (checkUuids.size() > 0) {
                 String list = "";
@@ -694,7 +695,7 @@ public class Lookup extends Queue {
             }
 
             String unionSelect = "SELECT * FROM (";
-            if (Config.getGlobal().DB_TYPE != DatabaseType.SQLITE) {
+            if (Config.getGlobal().DB_TYPE == DatabaseType.MYSQL) {
                 if (queryTable.equals("block")) {
                     if (includeBlock.length() > 0 || includeEntity.length() > 0) {
                         index = "USE INDEX(type) IGNORE INDEX(user,wid) ";
@@ -712,7 +713,7 @@ public class Lookup extends Queue {
 
                 unionSelect = "(";
             }
-            else {
+            else if (Config.getGlobal().DB_TYPE == DatabaseType.SQLITE) {
                 if (queryTable.equals("block")) {
                     if (includeBlock.length() > 0 || includeEntity.length() > 0) {
                         index = "INDEXED BY block_type_index ";
@@ -752,7 +753,11 @@ public class Lookup extends Queue {
                     baseQuery = baseQuery.replace("action NOT IN(-1)", "action NOT IN(3)"); // if block specified for include/exclude, filter out entity data
                 }
 
-                query = unionSelect + "SELECT " + "'0' as tbl," + rows + " FROM " + StatementUtils.getTableName("block") + " " + index + "WHERE" + baseQuery + unionLimit + ") UNION ALL ";
+                if (Config.getGlobal().DB_TYPE == DatabaseType.PGSQL) {
+                    alias = " AS union1";
+                }
+
+                query = unionSelect + "SELECT " + "'0' as tbl," + rows + " FROM " + StatementUtils.getTableName("block") + " " + index + "WHERE" + baseQuery + unionLimit + ")" + alias + " UNION ALL ";
                 itemLookup = true;
             }
 
@@ -760,7 +765,11 @@ public class Lookup extends Queue {
                 if (!count) {
                     rows = "rowid as id,time,\"user\",wid,x,y,z,type,metadata,data,amount,action,rolled_back";
                 }
-                query = query + unionSelect + "SELECT " + "'1' as tbl," + rows + " FROM " + StatementUtils.getTableName("container") + " WHERE" + queryBlock + unionLimit + ") UNION ALL ";
+
+                if (Config.getGlobal().DB_TYPE == DatabaseType.PGSQL) {
+                    alias = " AS union2";
+                }
+                query = query + unionSelect + "SELECT " + "'1' as tbl," + rows + " FROM " + StatementUtils.getTableName("container") + " WHERE" + queryBlock + unionLimit + ")" + alias + " UNION ALL ";
 
                 if (!count) {
                     rows = "rowid as id,time,\"user\",wid,x,y,z,type,data as metadata,0 as data,amount,action,rolled_back";
@@ -771,7 +780,10 @@ public class Lookup extends Queue {
                     queryBlock = queryBlock.replace("action NOT IN(-1)", "action NOT IN(" + actionExclude + ")");
                 }
 
-                query = query + unionSelect + "SELECT " + "'2' as tbl," + rows + " FROM " + StatementUtils.getTableName("item") + " WHERE" + queryBlock + unionLimit + ")";
+                if (Config.getGlobal().DB_TYPE == DatabaseType.PGSQL) {
+                    alias = " AS union3";
+                }
+                query = query + unionSelect + "SELECT " + "'2' as tbl," + rows + " FROM " + StatementUtils.getTableName("item") + " WHERE" + queryBlock + unionLimit + ")" + alias;
             }
 
             if (query.length() == 0) {

--- a/src/main/java/net/coreprotect/database/Lookup.java
+++ b/src/main/java/net/coreprotect/database/Lookup.java
@@ -356,7 +356,7 @@ public class Lookup extends Queue {
             String unionLimit = "";
             String index = "";
             String query = "";
-			String alias = "";
+            String alias = "";
 
             if (checkUuids.size() > 0) {
                 String list = "";


### PR DESCRIPTION
- Config option to supply extra parameters to the JDBC string for advanced cases.
- Example: Useful for connecting to Postgres behind pgbouncer when set to ?prepareThreshold=0
- Disables index hinting for Postgres
- Adds subquery aliases when creating unions
- Fixes creating prefixed username_log index at database initialization